### PR TITLE
Support more urls

### DIFF
--- a/mlarchive2maildir/commands.py
+++ b/mlarchive2maildir/commands.py
@@ -38,13 +38,14 @@ def cli_import(**kwargs):
     with locked_messageid_maildir(maildir_path) as maildir:
         if url.endswith('.txt') or url.endswith('.gz'):
             maildir.import_mbox_from_url(url, headers)
-        elif '/pipermail/' in url:
+        else:
             logger.debug('Querying {} for mbox urls'.format(url))
             mbox_urls = list(get_mbox_urls(url))
+            if len(mbox_urls) == 0:
+                click.echo(click.style('Unable to find any mboxes at {}, exiting!', fg='red'))
+                return -1
+
 
             with click.progressbar(mbox_urls) as bar:
                 for mbox_url in bar:
                     maildir.import_mbox_from_url(mbox_url, headers)
-        else:
-            click.echo(click.style('Unknown URL, exiting!', fg='red'))
-            return -1

--- a/mlarchive2maildir/pipermail.py
+++ b/mlarchive2maildir/pipermail.py
@@ -8,4 +8,6 @@ def get_mbox_urls(url):
     soup = BeautifulSoup(r.text, 'html.parser')
     for link in soup.find_all('a'):
         if 'Text' in link.text:
-            yield '{}/{}'.format(url, link.get('href'))
+            href = link.get('href')
+            if href.endswith('.txt') or href.endswith('.txt.gz'):
+                yield '{}/{}'.format(url, link.get('href'))


### PR DESCRIPTION
This does relax the requirement of having `/pipermail` in the URL, and just tries to parse a URL not directly pointing to an mbox file as a list, and will fail if it didn't manage to retrieve any mbox files.

Fixes importing for `lists.freedesktop.org`.